### PR TITLE
Fix clang on WIN32 without MINGW

### DIFF
--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -50,6 +50,11 @@ if( MSVC )
 		PUBLIC
 			$<BUILD_INTERFACE:${BX_DIR}/include/compat/msvc>
 			$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/msvc> )
+elseif ( NOT MSVC AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT MINGW ) # clang still uses msvc headers on windows.
+	target_include_directories( bx
+		PUBLIC
+			$<BUILD_INTERFACE:${BX_DIR}/include/compat/msvc>
+			$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/msvc> )
 elseif( MINGW )
 	target_include_directories( bx
 		PUBLIC

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -45,21 +45,16 @@ target_include_directories( bx
 		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
 
 # Build system specific configurations
-if( MSVC )
-	target_include_directories( bx
-		PUBLIC
-			$<BUILD_INTERFACE:${BX_DIR}/include/compat/msvc>
-			$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/msvc> )
-elseif ( NOT MSVC AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT MINGW ) # clang still uses msvc headers on windows.
-	target_include_directories( bx
-		PUBLIC
-			$<BUILD_INTERFACE:${BX_DIR}/include/compat/msvc>
-			$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/msvc> )
-elseif( MINGW )
+if( MINGW )
 	target_include_directories( bx
 		PUBLIC
 		    $<BUILD_INTERFACE:${BX_DIR}/include/compat/mingw>
 		    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/mingw> )
+elseif( WIN32 )
+	target_include_directories( bx
+		PUBLIC
+			$<BUILD_INTERFACE:${BX_DIR}/include/compat/msvc>
+			$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/compat/msvc> )
 elseif( APPLE )
 	target_include_directories( bx
 		PUBLIC


### PR DESCRIPTION
clang does not seem to be supported on the windows platform, this PR just adds support for it, so you wont require MINGW/MSYS2 to compile bgfx.cmake using clang