### PR TITLE
Fix android linking issues

### DIFF
--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -107,6 +107,12 @@ if( UNIX AND NOT APPLE AND NOT EMSCRIPTEN AND NOT ANDROID )
 	target_link_libraries( bgfx PUBLIC ${X11_LIBRARIES} ${OPENGL_LIBRARIES})
 endif()
 
+if ( ANDROID )
+	#The following commented libraries are linked by bx
+	#target_link_libraries( bgfx PUBLIC android log )
+	target_link_libraries( bgfx PUBLIC EGL )
+endif()
+
 # Exclude mm files if not on OS X
 if( NOT APPLE )
 	set_source_files_properties( ${BGFX_DIR}/src/glcontext_eagl.mm PROPERTIES HEADER_FILE_ONLY ON )

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -88,3 +88,8 @@ endif()
 
 # Put in a "bgfx" folder in Visual Studio
 set_target_properties( bx PROPERTIES FOLDER "bgfx" )
+
+# Android required libraries
+if (ANDROID)
+	target_link_libraries( bx PUBLIC android log )
+endif()


### PR DESCRIPTION
At the moment `bgfx.cmake` does not compile for Android, those changes allow bgfx, bimg and bx to be compiled for Android.