### PR TITLE
Use BGFX_DIR relative path when reading version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,6 @@
 cmake_minimum_required( VERSION 3.0 )
 project(bgfx)
 
-# sets project version from api ver / git rev
-include( cmake/version.cmake )
-
 set_property( GLOBAL PROPERTY USE_FOLDERS ON )
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -59,6 +56,9 @@ if( NOT BGFX_DIR )
 elseif( NOT IS_ABSOLUTE "${BGFX_DIR}")
 	get_filename_component(BGFX_DIR "${BGFX_DIR}" REALPATH BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
+
+# sets project version from api ver / git rev
+include( cmake/version.cmake )
 
 include( cmake/shared.cmake )
 include( cmake/bx.cmake )

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -23,7 +23,7 @@ execute_process(COMMAND "${GIT_EXECUTABLE}" -C bgfx rev-list --count HEAD
                 ERROR_QUIET)
 
 # read version(100) from bgfx.idl
-file(READ "${CMAKE_CURRENT_SOURCE_DIR}/bgfx/scripts/bgfx.idl" BGFX_IDL)
+file(READ "${BGFX_DIR}/scripts/bgfx.idl" BGFX_IDL)
 string(REGEX MATCH "version\\(([^\)]+)\\)"
        BGFX_API_VERSION ${BGFX_IDL})
 set(BGFX_API_VERSION ${CMAKE_MATCH_1})


### PR DESCRIPTION
My bgfx path is located outside of the bgfx.cmake repo path, this pull request allows cmake to generate my project.