### PR TITLE
Only include examples when examples or tools are built.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,9 @@ if( BGFX_BUILD_TOOLS )
 	include( cmake/tools.cmake )
 endif()
 
-include( cmake/examples.cmake )
+if( BGFX_BUILD_TOOLS OR BGFX_BUILD_EXAMPLES )
+	include( cmake/examples.cmake )
+endif()
 
 if( BGFX_INSTALL )
 	include(GNUInstallDirs)


### PR DESCRIPTION
tools/texturev and tools/geometryv depend on example-common.