### PR TITLE
bgfx: Add debug config required in bx headers since bx is private

### DIFF
--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -65,6 +65,14 @@ if( MSVC )
 	target_compile_definitions( bgfx PRIVATE "_CRT_SECURE_NO_WARNINGS" )
 endif()
 
+# Add debug config required in bx headers since bx is private
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    target_compile_definitions( bgfx PUBLIC "BX_CONFIG_DEBUG=1" )
+else()
+    target_compile_definitions( bgfx PUBLIC "BX_CONFIG_DEBUG=0" )
+endif()
+
+
 # Includes
 target_include_directories( bgfx
 	PRIVATE


### PR DESCRIPTION
This fixes the following error:
```
/usr/include/bx/config.h:10:9: error: #error "BX_CONFIG_DEBUG must be defined in build script!"
```