### PR TITLE
Use string compare for library type

### DIFF
--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -40,7 +40,11 @@ else()
 endif()
 
 # Create the bgfx target
-add_library( bgfx ${BGFX_LIBRARY_TYPE} ${BGFX_SOURCES} )
+if(BGFX_LIBRARY_TYPE STREQUAL STATIC)
+    add_library( bgfx STATIC ${BGFX_SOURCES} )
+else()
+    add_library( bgfx SHARED ${BGFX_SOURCES} )
+endif()
 
 if(BGFX_CONFIG_RENDERER_WEBGPU)
     include(cmake/3rdparty/webgpu.cmake)


### PR DESCRIPTION
In some cases using a variable for `STATIC` or `SHARED` will be taken as a filename.

```
Cannot find source file:

  "STATIC"

Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .h
.hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc
```

* cmake version 3.21.4
* ninja
* vcpkg
