### PR TITLE
BX_CONFIG_DEBUG via generator expression

### DIFF
--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -66,7 +66,7 @@ if( MSVC )
 endif()
 
 # Add debug config required in bx headers since bx is private
-target_compile_definitions(bgfx PUBLIC $<$<CONFIG:DEBUG>:BX_CONFIG_DEBUG=1> $<$<CONFIG:RELEASE>:BX_CONFIG_DEBUG=0>)
+target_compile_definitions(bgfx PUBLIC $<$<CONFIG:DEBUG>:BX_CONFIG_DEBUG=1> $<$<CONFIG:CHECKED>:BX_CONFIG_DEBUG=1> $<$<CONFIG:PROFILE>:BX_CONFIG_DEBUG=0> $<$<CONFIG:RELEASE>:BX_CONFIG_DEBUG=0>)
 
 # Includes
 target_include_directories( bgfx

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -66,12 +66,7 @@ if( MSVC )
 endif()
 
 # Add debug config required in bx headers since bx is private
-if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    target_compile_definitions( bgfx PUBLIC "BX_CONFIG_DEBUG=1" )
-else()
-    target_compile_definitions( bgfx PUBLIC "BX_CONFIG_DEBUG=0" )
-endif()
-
+target_compile_definitions(bgfx PUBLIC $<$<CONFIG:DEBUG>:BX_CONFIG_DEBUG=1> $<$<CONFIG:RELEASE>:BX_CONFIG_DEBUG=0>)
 
 # Includes
 target_include_directories( bgfx

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -66,7 +66,7 @@ if( MSVC )
 endif()
 
 # Add debug config required in bx headers since bx is private
-target_compile_definitions(bgfx PUBLIC $<$<CONFIG:DEBUG>:BX_CONFIG_DEBUG=1> $<$<CONFIG:CHECKED>:BX_CONFIG_DEBUG=1> $<$<CONFIG:PROFILE>:BX_CONFIG_DEBUG=0> $<$<CONFIG:RELEASE>:BX_CONFIG_DEBUG=0>)
+target_compile_definitions(bgfx PUBLIC "BX_CONFIG_DEBUG=$<CONFIG:Debug>")
 
 # Includes
 target_include_directories( bgfx

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -67,11 +67,7 @@ target_compile_definitions( bx PUBLIC "__STDC_LIMIT_MACROS" )
 target_compile_definitions( bx PUBLIC "__STDC_FORMAT_MACROS" )
 target_compile_definitions( bx PUBLIC "__STDC_CONSTANT_MACROS" )
 
-if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-	target_compile_definitions( bx PUBLIC "BX_CONFIG_DEBUG=1" )
-else()
-	target_compile_definitions( bx PUBLIC "BX_CONFIG_DEBUG=0" )
-endif()
+target_compile_definitions(bx PUBLIC $<$<CONFIG:DEBUG>:BX_CONFIG_DEBUG=1> $<$<CONFIG:RELEASE>:BX_CONFIG_DEBUG=0>)
 
 # Additional dependencies on Unix
 if( UNIX AND NOT APPLE AND NOT ANDROID )

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -67,7 +67,7 @@ target_compile_definitions( bx PUBLIC "__STDC_LIMIT_MACROS" )
 target_compile_definitions( bx PUBLIC "__STDC_FORMAT_MACROS" )
 target_compile_definitions( bx PUBLIC "__STDC_CONSTANT_MACROS" )
 
-target_compile_definitions(bx PUBLIC $<$<CONFIG:DEBUG>:BX_CONFIG_DEBUG=1> $<$<CONFIG:RELEASE>:BX_CONFIG_DEBUG=0>)
+target_compile_definitions(bx PUBLIC $<$<CONFIG:DEBUG>:BX_CONFIG_DEBUG=1> $<$<CONFIG:CHECKED>:BX_CONFIG_DEBUG=1> $<$<CONFIG:PROFILE>:BX_CONFIG_DEBUG=0> $<$<CONFIG:RELEASE>:BX_CONFIG_DEBUG=0>)
 
 # Additional dependencies on Unix
 if( UNIX AND NOT APPLE AND NOT ANDROID )

--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -67,7 +67,7 @@ target_compile_definitions( bx PUBLIC "__STDC_LIMIT_MACROS" )
 target_compile_definitions( bx PUBLIC "__STDC_FORMAT_MACROS" )
 target_compile_definitions( bx PUBLIC "__STDC_CONSTANT_MACROS" )
 
-target_compile_definitions(bx PUBLIC $<$<CONFIG:DEBUG>:BX_CONFIG_DEBUG=1> $<$<CONFIG:CHECKED>:BX_CONFIG_DEBUG=1> $<$<CONFIG:PROFILE>:BX_CONFIG_DEBUG=0> $<$<CONFIG:RELEASE>:BX_CONFIG_DEBUG=0>)
+target_compile_definitions(bx PUBLIC "BX_CONFIG_DEBUG=$<CONFIG:Debug>")
 
 # Additional dependencies on Unix
 if( UNIX AND NOT APPLE AND NOT ANDROID )


### PR DESCRIPTION
By making this a generator expression, environments like Xcode and Visual Studio can have correct BX_CONFIG_DEBUG behavior when picking debug or release in-IDE without needing to re-run the CMake generation.