### PR TITLE
bgfx: Do a case insensitive check for library type

### DIFF
--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -40,7 +40,8 @@ else()
 endif()
 
 # Create the bgfx target
-if(BGFX_LIBRARY_TYPE STREQUAL STATIC)
+string( TOLOWER "${BGFX_LIBRARY_TYPE}" BGFX_LIBRARY_TYPE)
+if(BGFX_LIBRARY_TYPE STREQUAL static)
     add_library( bgfx STATIC ${BGFX_SOURCES} )
 else()
     add_library( bgfx SHARED ${BGFX_SOURCES} )


### PR DESCRIPTION
When compiling bgfx.cmake to android using vcpkg, the library type ends up
being lower case.

This `TOLOWER` prevents this from happening and catches user errors.

The vcpkg config for bgfx is here https://github.com/openblack/openblack/tree/master/.vcpkg/ports/bgfx