### PR TITLE
Fixes for compiling on Android

### DIFF
--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -70,17 +70,22 @@ target_compile_definitions( bx PUBLIC "__STDC_CONSTANT_MACROS" )
 target_compile_definitions(bx PUBLIC "BX_CONFIG_DEBUG=$<CONFIG:Debug>")
 
 # Additional dependencies on Unix
-if( UNIX AND NOT APPLE AND NOT ANDROID )
+if (ANDROID)
+    # For __android_log_write
+    find_library( LOG_LIBRARY log )
+    mark_as_advanced( LOG_LIBRARY )
+	target_link_libraries( bx PUBLIC ${LOG_LIBRARY} )
+elseif( APPLE )
+	find_library( FOUNDATION_LIBRARY Foundation)
+	mark_as_advanced( FOUNDATION_LIBRARY )
+	target_link_libraries( bx PUBLIC ${FOUNDATION_LIBRARY} )
+elseif( UNIX )
 	# Threads
 	find_package( Threads )
 	target_link_libraries( bx ${CMAKE_THREAD_LIBS_INIT} dl )
 
 	# Real time (for clock_gettime)
 	target_link_libraries( bx rt )
-elseif(APPLE)
-	find_library( FOUNDATION_LIBRARY Foundation)
-	mark_as_advanced( FOUNDATION_LIBRARY )
-	target_link_libraries( bx PUBLIC ${FOUNDATION_LIBRARY} )
 endif()
 
 # Put in a "bgfx" folder in Visual Studio

--- a/cmake/examples.cmake
+++ b/cmake/examples.cmake
@@ -171,7 +171,7 @@ function( add_example ARG_NAME )
 	target_compile_definitions( example-${ARG_NAME} PRIVATE "-D_CRT_SECURE_NO_WARNINGS" "-D__STDC_FORMAT_MACROS" "-DENTRY_CONFIG_IMPLEMENT_MAIN=1" )
 
 	# Configure shaders
-	if( NOT ARG_COMMON AND NOT IOS AND NOT EMSCRIPTEN)
+	if( NOT ARG_COMMON AND NOT IOS AND NOT EMSCRIPTEN AND NOT ANDROID)
 		foreach( SHADER ${SHADERS} )
 			add_bgfx_shader( ${SHADER} ${ARG_NAME} )
 		endforeach()


### PR DESCRIPTION
1. bx needs to link with android's log library
2. Like with Emscripten and iOS, don't build examples by default on Android