### PR TITLE
update bx to require c++14 and add compiler flag for bx when using MSVC

### DIFF
--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -30,6 +30,10 @@ endif()
 # Create the bx target
 add_library( bx STATIC ${BX_SOURCES} )
 
+target_compile_features( bx PUBLIC cxx_std_14 )
+# (note: see bx\scripts\toolchain.lua for equivalent compiler flag)
+target_compile_options( bx PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus> )
+
 # Link against psapi on Windows
 if( WIN32 )
 	target_link_libraries( bx PUBLIC psapi )


### PR DESCRIPTION
I realize https://github.com/bkaradzic/bgfx.cmake/commit/896ab5478cd943c51fe14ff8e4a1abf7b4102bca did resolve this issue, but to make things more `target` friendly and as this only really impacts `bx` and no other libraries, I propose we add this change here and (potentially) remove the global `add_compile_options`. (I also updated `bgfx` to the latest commit in the process, I can create a new PR without this if it's an issue). Thanks!