### PR TITLE
Fix emscripten's build

### DIFF
--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -56,6 +56,10 @@ if(BGFX_CONFIG_RENDERER_WEBGPU)
     endif()
 endif()
 
+if(EMSCRIPTEN)
+	target_link_options(bgfx PUBLIC "-sMAX_WEBGL_VERSION=2")
+endif()
+
 if( NOT ${BGFX_OPENGL_VERSION} STREQUAL "" )
 	target_compile_definitions( bgfx PRIVATE BGFX_CONFIG_RENDERER_OPENGL_MIN_VERSION=${BGFX_OPENGL_VERSION} )
 endif()

--- a/cmake/examples.cmake
+++ b/cmake/examples.cmake
@@ -179,10 +179,12 @@ function( add_example ARG_NAME )
 	endif()
 
 	if (NOT ARG_COMMON AND EMSCRIPTEN)
-		target_link_libraries(example-${ARG_NAME}
-			"-s PRECISE_F32=1"
-			"-s TOTAL_MEMORY=268435456"
-			"--memory-init-file 1")
+		set_target_properties(example-${ARG_NAME}
+			PROPERTIES
+				LINK_FLAGS
+					"-s PRECISE_F32=1 -s TOTAL_MEMORY=268435456 -s ENVIRONMENT=web --memory-init-file 1 --emrun"
+				SUFFIX ".html"
+		)
 	endif()
 
 	# Directory name


### PR DESCRIPTION
Fixes the issue raised in https://github.com/bkaradzic/bgfx/discussions/2580

* Set examples as htmls in emscripten builds
* Specify WebGL2 which fixes linker error