### PR TITLE
Use commit count for tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,11 @@ jobs:
       - id: version
         run: |
           API_VERSION=$(grep -Eo "BGFX_API_VERSION UINT32_C\([0-9]+\)" bgfx/include/bgfx/defines.h | grep -Eo "[0-9]+" | tail -1)
-          REVISION=$(cd bgfx && git rev-list HEAD --count)
+          BGFX_REVISION=$(cd bgfx && git rev-list HEAD --count)
+          BGFX_CMAKE_REVISION=$(git rev-list HEAD --count)
           SHA=$(cd bgfx && git rev-parse HEAD)
-          SHA7="${GITHUB_SHA::7}"
-          TAG="v1.${API_VERSION}.${REVISION}-${SHA7}"
-          echo "::set-output name=revision::${REVISION}"
+          TAG="v1.${API_VERSION}.${BGFX_REVISION}-${BGFX_CMAKE_REVISION}"
+          echo "::set-output name=revision::${BGFX_REVISION}"
           echo "::set-output name=sha::${SHA}"
           echo "::set-output name=tag::${TAG}"
 


### PR DESCRIPTION
In the case where the cmake package has been updated but bgfx submodules haven't it is more informative to have the commit count than the sha.

Proposed
```
1.115.8264.337
^ ^^^ ^^^^ ^^^
| |   |    +-- bgfx.cmake commit number (https://github.com/bkaradzic/bgfx.cmake / git rev-list --count HEAD)
| |   +------- Commit number            (https://github.com/bkaradzic/bgfx / git rev-list --count HEAD)
| +----------- API version              (from https://github.com/bkaradzic/bgfx/blob/master/scripts/bgfx.idl#L4)
+------------- Major revision           (always 1)
```