### PR TITLE
3rdparty: prefix `bgfx-` to lib names to avoid conflicts

### DIFF
--- a/cmake/3rdparty/astc-encoder.cmake
+++ b/cmake/3rdparty/astc-encoder.cmake
@@ -25,4 +25,6 @@ target_include_directories( astc-encoder
 		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty>
 		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/astc-encoder>
 		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/astc-encoder/include> )
-set_target_properties( astc-encoder PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( astc-encoder
+	PROPERTIES
+		FOLDER "bgfx/3rdparty" )

--- a/cmake/3rdparty/dear-imgui.cmake
+++ b/cmake/3rdparty/dear-imgui.cmake
@@ -18,4 +18,7 @@ add_library( dear-imgui STATIC EXCLUDE_FROM_ALL ${dear_IMGUI_SOURCES} )
 target_compile_definitions( dear-imgui PRIVATE "-D_CRT_SECURE_NO_WARNINGS" "-D__STDC_FORMAT_MACROS" )
 target_include_directories( dear-imgui PUBLIC ${BGFX_DIR}/3rdparty )
 target_link_libraries( dear-imgui PUBLIC bx )
-set_target_properties( dear-imgui PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( dear-imgui
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/edtaa3.cmake
+++ b/cmake/3rdparty/edtaa3.cmake
@@ -16,4 +16,7 @@ file( GLOB EDTAA3_SOURCES ${BIMG_DIR}/3rdparty/edtaa3/*.cpp ${BIMG_DIR}/3rdparty
 
 add_library( edtaa3 STATIC ${EDTAA3_SOURCES} )
 target_include_directories( edtaa3 PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
-set_target_properties( edtaa3 PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( edtaa3
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/etc1.cmake
+++ b/cmake/3rdparty/etc1.cmake
@@ -16,4 +16,7 @@ file( GLOB ETC1_SOURCES ${BIMG_DIR}/3rdparty/etc1/*.cpp ${BIMG_DIR}/3rdparty/etc
 
 add_library( etc1 STATIC ${ETC1_SOURCES} )
 target_include_directories( etc1 PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
-set_target_properties( etc1 PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( etc1
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/etc2.cmake
+++ b/cmake/3rdparty/etc2.cmake
@@ -16,5 +16,8 @@ file( GLOB ETC2_SOURCES ${BIMG_DIR}/3rdparty/etc2/*.cpp ${BIMG_DIR}/3rdparty/etc
 
 add_library( etc2 STATIC ${ETC2_SOURCES} )
 target_include_directories( etc2 PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
-set_target_properties( etc2 PROPERTIES FOLDER "bgfx/3rdparty" )
 target_link_libraries( etc2 PUBLIC bx )
+set_target_properties( etc2
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/fcpp.cmake
+++ b/cmake/3rdparty/fcpp.cmake
@@ -28,5 +28,8 @@ if( MSVC )
 	set_target_properties( fcpp PROPERTIES COMPILE_FLAGS "/W0" )
 endif()
 
-set_target_properties( fcpp PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( fcpp
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )
 set_source_files_properties( ${BGFX_DIR}/3rdparty/fcpp/usecpp.c PROPERTIES HEADER_FILE_ONLY ON )

--- a/cmake/3rdparty/glsl-optimizer.cmake
+++ b/cmake/3rdparty/glsl-optimizer.cmake
@@ -84,4 +84,7 @@ elseif(APPLE)
 		-Wno-deprecated-register
 	)
 endif()
-set_target_properties( glsl-optimizer PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( glsl-optimizer
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/glslang.cmake
+++ b/cmake/3rdparty/glslang.cmake
@@ -40,7 +40,10 @@ target_include_directories( glslang PUBLIC
 	${BGFX_DIR}/3rdparty
 )
 
-set_target_properties( glslang PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( glslang
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )
 
 if( MSVC )
 	target_compile_options( glslang PRIVATE

--- a/cmake/3rdparty/iqa.cmake
+++ b/cmake/3rdparty/iqa.cmake
@@ -16,4 +16,7 @@ file( GLOB IQA_SOURCES ${BIMG_DIR}/3rdparty/iqa/source/*.c ${BIMG_DIR}/3rdparty/
 
 add_library( iqa STATIC ${IQA_SOURCES} )
 target_include_directories( iqa PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/iqa/include> )
-set_target_properties( iqa PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( iqa
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/libsquish.cmake
+++ b/cmake/3rdparty/libsquish.cmake
@@ -16,4 +16,7 @@ file( GLOB SQUISH_SOURCES ${BIMG_DIR}/3rdparty/libsquish/*.cpp ${BIMG_DIR}/3rdpa
 
 add_library( squish STATIC ${SQUISH_SOURCES} )
 target_include_directories( squish PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
-set_target_properties( squish PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( squish
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/meshoptimizer.cmake
+++ b/cmake/3rdparty/meshoptimizer.cmake
@@ -16,4 +16,7 @@ file( GLOB MESHOPTIMIZER_SOURCES ${BGFX_DIR}/3rdparty/meshoptimizer/src/*.cpp ${
 
 add_library( meshoptimizer STATIC ${MESHOPTIMIZER_SOURCES} )
 target_include_directories( meshoptimizer PUBLIC ${BGFX_DIR}/3rdparty )
-set_target_properties( meshoptimizer PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( meshoptimizer
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/nvtt.cmake
+++ b/cmake/3rdparty/nvtt.cmake
@@ -32,5 +32,8 @@ target_include_directories( nvtt
 	PUBLIC
 		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty>
 		$<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/nvtt> )
-set_target_properties( nvtt PROPERTIES FOLDER "bgfx/3rdparty" )
 target_link_libraries( nvtt PUBLIC bx )
+set_target_properties( nvtt
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/pvrtc.cmake
+++ b/cmake/3rdparty/pvrtc.cmake
@@ -16,4 +16,7 @@ file( GLOB PVRTC_SOURCES ${BIMG_DIR}/3rdparty/pvrtc/*.cpp ${BIMG_DIR}/3rdparty/p
 
 add_library( pvrtc STATIC ${PVRTC_SOURCES} )
 target_include_directories( pvrtc PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> )
-set_target_properties( pvrtc PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( pvrtc
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/spirv-cross.cmake
+++ b/cmake/3rdparty/spirv-cross.cmake
@@ -35,4 +35,7 @@ if( MSVC )
 	)
 endif()
 
-set_target_properties( spirv-cross PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( spirv-cross
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/spirv-tools.cmake
+++ b/cmake/3rdparty/spirv-tools.cmake
@@ -55,4 +55,7 @@ else()
 	endif()
 endif()
 
-set_target_properties( spirv-tools PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( spirv-tools
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/tinyexr.cmake
+++ b/cmake/3rdparty/tinyexr.cmake
@@ -6,4 +6,7 @@ file( GLOB_RECURSE TINYEXR_SOURCES ${BIMG_DIR}/3rdparty/tinyexr/*.c ${BIMG_DIR}/
 
 add_library( tinyexr STATIC ${TINYEXR_SOURCES} )
 target_include_directories( tinyexr PUBLIC $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty> $<BUILD_INTERFACE:${BIMG_DIR}/3rdparty/tinyexr/deps/miniz> )
-set_target_properties( tinyexr PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( tinyexr
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )

--- a/cmake/3rdparty/webgpu.cmake
+++ b/cmake/3rdparty/webgpu.cmake
@@ -28,4 +28,7 @@ target_include_directories( webgpu
 	    $<BUILD_INTERFACE:${BGFX_DIR}/3rdparty/webgpu/include>
 )
 
-# set_target_properties( webgpu PROPERTIES FOLDER "bgfx/3rdparty" )
+set_target_properties( webgpu
+	PROPERTIES
+		FOLDER "bgfx/3rdparty"
+		PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}bgfx-" )


### PR DESCRIPTION
Fixes name clashes with installed libraries in cases where bgfx uses a fork of a 3rdparty library that a system already has.
The change prefixes `(lib)bgfx-` to the generated artifact (static or shared) to make it clear that an installed lib is a fork and thus preventing name clashes.

An example of this issue is in the vcpkg repo the bgfx package installs `nvtt.lib` under windows which causes conflicts with the actual nvtt package.

The two libs are sufficiently different that the bgfx package cannot use vcpkg's nvtt. This was a fix that the microsoft folks attempted.