### PR TITLE
Update for recent shaderc changes in handling dx profile strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: recursive  
+          submodules: recursive
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
@@ -56,3 +56,8 @@ jobs:
       - name: Build
         run: |
           cmake --build "${{ env.CMAKE_BUILD_DIR }}"
+
+      # Build the examples which are excluded from all
+      - name: Build examples
+        run: |
+          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ option(BGFX_CONFIG_DEBUG_ANNOTATION "Enable gfx debug annotations (default: on i
 set(BGFX_OPENGL_VERSION "" CACHE STRING "Specify minimum opengl version")
 set(BGFX_OPENGLES_VERSION "" CACHE STRING "Specify minimum OpenGL ES version")
 set(BGFX_LIBRARY_TYPE "STATIC" CACHE STRING "Linking type for library")
+set_property(CACHE BGFX_LIBRARY_TYPE PROPERTY STRINGS "STATIC" "SHARED")
 
 set(BGFX_CONFIG_DEFAULT_MAX_ENCODERS "" CACHE STRING "Specify default maximum encoder count (multithreaded only)")
 set(BGFX_CONFIG_MAX_DRAW_CALLS "" CACHE STRING "Specify maximum draw calls")
@@ -71,9 +72,7 @@ if(BGFX_CMAKE_USER_SCRIPT)
 	include(${BGFX_CMAKE_USER_SCRIPT})
 endif()
 
-set_property(CACHE BGFX_LIBRARY_TYPE PROPERTY STRINGS STATIC SHARED)
-
-if(BGFX_LIBRARY_TYPE MATCHES "SHARED")
+if(BGFX_LIBRARY_TYPE MATCHES "STATIC")
 	set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 

--- a/cmake/bgfx/examples.cmake
+++ b/cmake/bgfx/examples.cmake
@@ -160,6 +160,50 @@ function(add_example ARG_NAME)
 		elseif(UNIX AND NOT APPLE)
 			target_link_libraries(example-${ARG_NAME} PUBLIC X11)
 		endif()
+
+		if(BGFX_BUILD_EXAMPLES)
+			if(IOS OR WIN32)
+				# on iOS we need to build a bundle so have to copy the data rather than symlink
+				# and on windows we can't create symlinks
+				add_custom_command(
+					TARGET example-${ARG_NAME} COMMAND ${CMAKE_COMMAND} -E copy_directory ${BGFX_DIR}/examples/runtime/
+													   $<TARGET_FILE_DIR:example-${ARG_NAME}>
+				)
+			else()
+				# For everything else symlink some folders into our output directory
+				add_custom_command(
+					TARGET example-${ARG_NAME}
+					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/font
+							$<TARGET_FILE_DIR:example-${ARG_NAME}>/font
+				)
+				add_custom_command(
+					TARGET example-${ARG_NAME}
+					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/images
+							$<TARGET_FILE_DIR:example-${ARG_NAME}>/images
+				)
+				add_custom_command(
+					TARGET example-${ARG_NAME}
+					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/meshes
+							$<TARGET_FILE_DIR:example-${ARG_NAME}>/meshes
+				)
+				add_custom_command(
+					TARGET example-${ARG_NAME}
+					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/shaders
+							$<TARGET_FILE_DIR:example-${ARG_NAME}>/shaders
+				)
+				add_custom_command(
+					TARGET example-${ARG_NAME}
+					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/text
+							$<TARGET_FILE_DIR:example-${ARG_NAME}>/text
+				)
+				add_custom_command(
+					TARGET example-${ARG_NAME}
+					COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/textures
+							$<TARGET_FILE_DIR:example-${ARG_NAME}>/textures
+				)
+			endif()
+		endif()
+
 	else()
 		if(BGFX_INSTALL_EXAMPLES)
 			add_executable(example-${ARG_NAME} WIN32 ${SOURCES})
@@ -213,42 +257,6 @@ function(add_example ARG_NAME)
 
 	# Directory name
 	set_target_properties(example-${ARG_NAME} PROPERTIES FOLDER "bgfx/examples")
-
-	if(IOS OR WIN32)
-		# on iOS we need to build a bundle so have to copy the data rather than symlink
-		# and on windows we can't create symlinks
-		add_custom_command(
-			TARGET example-${ARG_NAME} COMMAND ${CMAKE_COMMAND} -E copy_directory ${BGFX_DIR}/examples/runtime/
-											   $<TARGET_FILE_DIR:example-${ARG_NAME}>
-		)
-	else()
-		# For everything else symlink some folders into our output directory
-		add_custom_command(
-			TARGET example-${ARG_NAME} COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/font
-											   $<TARGET_FILE_DIR:example-${ARG_NAME}>/font
-		)
-		add_custom_command(
-			TARGET example-${ARG_NAME} COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/images
-											   $<TARGET_FILE_DIR:example-${ARG_NAME}>/images
-		)
-		add_custom_command(
-			TARGET example-${ARG_NAME} COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/meshes
-											   $<TARGET_FILE_DIR:example-${ARG_NAME}>/meshes
-		)
-		add_custom_command(
-			TARGET example-${ARG_NAME} COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/shaders
-											   $<TARGET_FILE_DIR:example-${ARG_NAME}>/shaders
-		)
-		add_custom_command(
-			TARGET example-${ARG_NAME} COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/text
-											   $<TARGET_FILE_DIR:example-${ARG_NAME}>/text
-		)
-		add_custom_command(
-			TARGET example-${ARG_NAME} COMMAND ${CMAKE_COMMAND} -E create_symlink ${BGFX_DIR}/examples/runtime/textures
-											   $<TARGET_FILE_DIR:example-${ARG_NAME}>/textures
-		)
-	endif()
-
 endfunction()
 
 # Build all examples target

--- a/cmake/bgfx/examples.cmake
+++ b/cmake/bgfx/examples.cmake
@@ -19,13 +19,10 @@ function(add_bgfx_shader FILE FOLDER)
 	string(SUBSTRING "${FILENAME}" 0 2 TYPE)
 	if("${TYPE}" STREQUAL "fs")
 		set(TYPE "FRAGMENT")
-		set(D3D_PREFIX "ps")
 	elseif("${TYPE}" STREQUAL "vs")
 		set(TYPE "VERTEX")
-		set(D3D_PREFIX "vs")
 	elseif("${TYPE}" STREQUAL "cs")
 		set(TYPE "COMPUTE")
-		set(D3D_PREFIX "cs")
 	else()
 		set(TYPE "")
 	endif()
@@ -41,7 +38,7 @@ function(add_bgfx_shader FILE FOLDER)
 				set(DX9_OUTPUT ${BGFX_DIR}/examples/runtime/shaders/dx9/${FILENAME}.bin)
 				_bgfx_shaderc_parse(
 					DX9 ${COMMON} WINDOWS
-					PROFILE ${D3D_PREFIX}_3_0
+					PROFILE s_3_0
 					O 3
 					OUTPUT ${DX9_OUTPUT}
 				)
@@ -54,14 +51,14 @@ function(add_bgfx_shader FILE FOLDER)
 			if(NOT "${TYPE}" STREQUAL "COMPUTE")
 				_bgfx_shaderc_parse(
 					DX11 ${COMMON} WINDOWS
-					PROFILE ${D3D_PREFIX}_5_0
+					PROFILE s_5_0
 					O 3
 					OUTPUT ${DX11_OUTPUT}
 				)
 			else()
 				_bgfx_shaderc_parse(
 					DX11 ${COMMON} WINDOWS
-					PROFILE ${D3D_PREFIX}_5_0
+					PROFILE s_5_0
 					O 1
 					OUTPUT ${DX11_OUTPUT}
 				)

--- a/cmake/bgfx/examples.cmake
+++ b/cmake/bgfx/examples.cmake
@@ -86,7 +86,7 @@ function(add_bgfx_shader FILE FOLDER)
 		# glsl
 		set(GLSL_OUTPUT ${BGFX_DIR}/examples/runtime/shaders/glsl/${FILENAME}.bin)
 		if(NOT "${TYPE}" STREQUAL "COMPUTE")
-			_bgfx_shaderc_parse(GLSL ${COMMON} LINUX PROFILE 120 OUTPUT ${GLSL_OUTPUT})
+			_bgfx_shaderc_parse(GLSL ${COMMON} LINUX PROFILE 140 OUTPUT ${GLSL_OUTPUT})
 		else()
 			_bgfx_shaderc_parse(GLSL ${COMMON} LINUX PROFILE 430 OUTPUT ${GLSL_OUTPUT})
 		endif()


### PR DESCRIPTION
Removed D3D_PREFIX and changed profile string values to match the current version of shaderc.

Without this change, examples don't build properly on windows.