### PR TITLE
Add option to prefix tool names to avoid conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ cmake_dependent_option(BGFX_BUILD_TOOLS_BIN2C "Build bx binary to c converter." 
 cmake_dependent_option(BGFX_BUILD_TOOLS_SHADER "Build bgfx shader tools." ON BGFX_BUILD_TOOLS OFF)
 cmake_dependent_option(BGFX_BUILD_TOOLS_GEOMETRY "Build bgfx geometry tools." ON BGFX_BUILD_TOOLS OFF)
 cmake_dependent_option(BGFX_BUILD_TOOLS_TEXTURE "Build bgfx texture tools." ON BGFX_BUILD_TOOLS OFF)
+set(BGFX_TOOLS_PREFIX "" CACHE STRING "Prefix name to add to name of tools (to avoid clashes)")
 option(BGFX_BUILD_EXAMPLES "Build bgfx examples." ON)
 option(BGFX_BUILD_TESTS "Build bgfx tests." OFF)
 option(BGFX_INSTALL "Create installation target." ON)

--- a/cmake/bgfx/geometryc.cmake
+++ b/cmake/bgfx/geometryc.cmake
@@ -24,7 +24,10 @@ target_sources(geometryc PRIVATE ${GEOMETRYC_SOURCES})
 target_include_directories(geometryc PRIVATE ${MESHOPTIMIZER_INCLUDE_DIR})
 target_link_libraries(geometryc PRIVATE bx bgfx-vertexlayout ${MESHOPTIMIZER_LIBRARIES})
 target_compile_definitions(geometryc PRIVATE "-D_CRT_SECURE_NO_WARNINGS")
-set_target_properties(geometryc PROPERTIES FOLDER "bgfx/tools")
+set_target_properties(
+	geometryc PROPERTIES FOLDER "bgfx/tools" #
+						 OUTPUT_NAME ${BGFX_TOOLS_PREFIX}geometryc #
+)
 
 if(BGFX_BUILD_TOOLS_GEOMETRY AND BGFX_CUSTOM_TARGETS)
 	add_dependencies(tools geometryc)

--- a/cmake/bgfx/geometryv.cmake
+++ b/cmake/bgfx/geometryv.cmake
@@ -17,7 +17,10 @@ file(GLOB_RECURSE GEOMETRYV_SOURCES #
 
 target_sources(geometryv PRIVATE ${GEOMETRYV_SOURCES})
 target_link_libraries(geometryv example-common)
-set_target_properties(geometryv PROPERTIES FOLDER "bgfx/tools")
+set_target_properties(
+	geometryv PROPERTIES FOLDER "bgfx/tools" #
+						 OUTPUT_NAME ${BGFX_TOOLS_PREFIX}geometryv #
+)
 
 if(BGFX_BUILD_TOOLS_GEOMETRY AND BGFX_CUSTOM_TARGETS)
 	add_dependencies(tools geometryv)

--- a/cmake/bgfx/shaderc.cmake
+++ b/cmake/bgfx/shaderc.cmake
@@ -57,7 +57,10 @@ file(
 
 target_sources(shaderc PRIVATE ${SHADERC_SOURCES})
 
-set_target_properties(geometryc PROPERTIES FOLDER "bgfx/tools")
+set_target_properties(
+	shaderc PROPERTIES FOLDER "bgfx/tools" #
+					   OUTPUT_NAME ${BGFX_TOOLS_PREFIX}shaderc #
+)
 
 if(BGFX_BUILD_TOOLS_SHADER AND BGFX_CUSTOM_TARGETS)
 	add_dependencies(tools shaderc)

--- a/cmake/bgfx/texturev.cmake
+++ b/cmake/bgfx/texturev.cmake
@@ -17,7 +17,10 @@ file(GLOB_RECURSE TEXTUREV_SOURCES #
 
 target_sources(texturev PRIVATE ${TEXTUREV_SOURCES})
 target_link_libraries(texturev PRIVATE example-common)
-set_target_properties(texturev PROPERTIES FOLDER "bgfx/tools")
+set_target_properties(
+	texturev PROPERTIES FOLDER "bgfx/tools" #
+						OUTPUT_NAME ${BGFX_TOOLS_PREFIX}texturev #
+)
 
 if(BGFX_BUILD_TOOLS_TEXTURE AND BGFX_CUSTOM_TARGETS)
 	add_dependencies(tools texturev)

--- a/cmake/bimg/texturec.cmake
+++ b/cmake/bimg/texturec.cmake
@@ -18,7 +18,10 @@ file(GLOB_RECURSE TEXTUREC_SOURCES #
 
 target_sources(texturec PRIVATE ${TEXTUREC_SOURCES})
 target_link_libraries(texturec PRIVATE bimg_decode bimg_encode bimg)
-set_target_properties(texturec PROPERTIES FOLDER "bgfx/tools")
+set_target_properties(
+	texturec PROPERTIES FOLDER "bgfx/tools" #
+						OUTPUT_NAME ${BGFX_TOOLS_PREFIX}texturec #
+)
 
 if(BGFX_BUILD_TOOLS_TEXTURE AND BGFX_CUSTOM_TARGETS)
 	add_dependencies(tools texturec)

--- a/cmake/bx/bin2c.cmake
+++ b/cmake/bx/bin2c.cmake
@@ -18,7 +18,10 @@ file(GLOB_RECURSE BIN2C_SOURCES #
 
 target_sources(bin2c PRIVATE ${BIN2C_SOURCES})
 target_link_libraries(bin2c PRIVATE bx)
-set_target_properties(bin2c PROPERTIES FOLDER "bgfx/tools")
+set_target_properties(
+	bin2c PROPERTIES FOLDER "bgfx/tools" #
+					 OUTPUT_NAME ${BGFX_TOOLS_PREFIX}bin2c #
+)
 
 if(BGFX_BUILD_TOOLS_BIN2C AND BGFX_CUSTOM_TARGETS)
 	add_dependencies(tools bin2c)


### PR DESCRIPTION
For example the shaderc is used by dawn and an installation might want to prefix bgfx's shaderc with bgfx-shaderc