### PR TITLE
Fix targeted project in shaderc.cmake

### DIFF
--- a/cmake/bgfx/shaderc.cmake
+++ b/cmake/bgfx/shaderc.cmake
@@ -57,7 +57,7 @@ file(
 
 target_sources(shaderc PRIVATE ${SHADERC_SOURCES})
 
-set_target_properties(geometryc PROPERTIES FOLDER "bgfx/tools")
+set_target_properties(shaderc PROPERTIES FOLDER "bgfx/tools")
 
 if(BGFX_BUILD_TOOLS_SHADER AND BGFX_CUSTOM_TARGETS)
 	add_dependencies(tools shaderc)


### PR DESCRIPTION
I believe this is a copy-pasta 🍝 issue.

Maybe we could use ${PROJECT_NAME} to avoid this kind of typo?