### PR TITLE
Ensure BX_DIR is converted to native pathname

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,10 @@ elseif(NOT IS_ABSOLUTE "${BGFX_DIR}")
 	get_filename_component(BGFX_DIR "${BGFX_DIR}" REALPATH BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
+file(TO_CMAKE_PATH "${BX_DIR}" BX_DIR)
+file(TO_CMAKE_PATH "${BIMG_DIR}" BIMG_DIR)
+file(TO_CMAKE_PATH "${BGFX_DIR}" BGFX_DIR)
+
 # sets project version from api ver / git rev
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.cmake)
 if(BGFX_BUILD_TOOLS AND BGFX_CUSTOM_TARGETS)


### PR DESCRIPTION
When using the BX_DIR, BIMG_DIR, and BGFX_DIR options to cmake, the pathnames need to be converted to native format. This ensures the paths do not have mixed directory separators later on in the build, which can cause build failures.