### PR TITLE
Change CMake Minum Required Version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # You should have received a copy of the CC0 Public Domain Dedication along with
 # this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.19)
 project(bgfx)
 cmake_policy(SET CMP0054 NEW)
 


### PR DESCRIPTION
This changes the minimum required version for cmake, as versions earlier than 3.19 cause a problem with the cmake.