### PR TITLE
Improvments on the shader compiler utility

### DIFF
--- a/cmake/bgfx/examples.cmake
+++ b/cmake/bgfx/examples.cmake
@@ -105,7 +105,7 @@ function(add_bgfx_shader FILE FOLDER)
 
 		foreach(OUT ${OUTPUTS})
 			list(APPEND OUTPUT_FILES ${${OUT}_OUTPUT})
-			list(APPEND COMMANDS COMMAND "$<TARGET_FILE:shaderc>" ${${OUT}})
+			list(APPEND COMMANDS COMMAND "bgfx::shaderc" ${${OUT}})
 			get_filename_component(OUT_DIR ${${OUT}_OUTPUT} DIRECTORY)
 			file(MAKE_DIRECTORY ${OUT_DIR})
 		endforeach()

--- a/cmake/bgfx/geometryc.cmake
+++ b/cmake/bgfx/geometryc.cmake
@@ -27,13 +27,10 @@ set_target_properties(
 						 OUTPUT_NAME ${BGFX_TOOLS_PREFIX}geometryc #
 )
 
-if(BGFX_BUILD_TOOLS_GEOMETRY AND BGFX_CUSTOM_TARGETS)
-	add_dependencies(tools geometryc)
-endif()
-
 if(BGFX_BUILD_TOOLS_GEOMETRY)
-	if(TARGET geometryc AND NOT TARGET bgfx::geometryc)
-		add_executable(bgfx::geometryc ALIAS geometryc)
+	add_executable(bgfx::geometryc ALIAS geometryc)
+	if(BGFX_CUSTOM_TARGETS)
+		add_dependencies(tools geometryc)
 	endif()
 endif()
 

--- a/cmake/bgfx/geometryc.cmake
+++ b/cmake/bgfx/geometryc.cmake
@@ -31,6 +31,12 @@ if(BGFX_BUILD_TOOLS_GEOMETRY AND BGFX_CUSTOM_TARGETS)
 	add_dependencies(tools geometryc)
 endif()
 
+if(BGFX_BUILD_TOOLS_GEOMETRY)
+	if(TARGET geometryc AND NOT TARGET bgfx::geometryc)
+		add_executable(bgfx::geometryc ALIAS geometryc)
+	endif()
+endif()
+
 if(IOS)
 	set_target_properties(geometryc PROPERTIES MACOSX_BUNDLE ON MACOSX_BUNDLE_GUI_IDENTIFIER geometryc)
 endif()

--- a/cmake/bgfx/shaderc.cmake
+++ b/cmake/bgfx/shaderc.cmake
@@ -54,6 +54,12 @@ if(BGFX_BUILD_TOOLS_SHADER AND BGFX_CUSTOM_TARGETS)
 	add_dependencies(tools shaderc)
 endif()
 
+if(BGFX_BUILD_TOOLS_SHADER)
+	if(TARGET shaderc AND NOT TARGET bgfx::shaderc)
+		add_executable(bgfx::shaderc ALIAS shaderc)
+	endif()
+endif()
+
 if(ANDROID)
 	target_link_libraries(shaderc PRIVATE log)
 elseif(IOS)

--- a/cmake/bgfx/shaderc.cmake
+++ b/cmake/bgfx/shaderc.cmake
@@ -50,13 +50,10 @@ set_target_properties(
 					   OUTPUT_NAME ${BGFX_TOOLS_PREFIX}shaderc #
 )
 
-if(BGFX_BUILD_TOOLS_SHADER AND BGFX_CUSTOM_TARGETS)
-	add_dependencies(tools shaderc)
-endif()
-
 if(BGFX_BUILD_TOOLS_SHADER)
-	if(TARGET shaderc AND NOT TARGET bgfx::shaderc)
-		add_executable(bgfx::shaderc ALIAS shaderc)
+	add_executable(bgfx::shaderc ALIAS shaderc)
+	if(BGFX_CUSTOM_TARGETS)
+		add_dependencies(tools shaderc)
 	endif()
 endif()
 

--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -535,12 +535,14 @@ endfunction()
 # 	SHADERS filenames
 # 	VARYING_DEF filename
 # 	OUTPUT_DIR directory
+# 	OUT_FILES_VAR variable name
+# 	INCLUDE_DIRS directories
 # )
 #
 function(bgfx_compile_shader_to_header)
 	set(options "")
-	set(oneValueArgs TYPE VARYING_DEF OUTPUT_DIR)
-	set(multiValueArgs SHADERS)
+	set(oneValueArgs TYPE VARYING_DEF OUTPUT_DIR OUT_FILES_VAR)
+	set(multiValueArgs SHADERS INCLUDE_DIRS)
 	cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
 
 	set(PROFILES 120 300_es spirv) # pssl
@@ -596,12 +598,15 @@ function(bgfx_compile_shader_to_header)
 				PROFILE ${PROFILE}
 				O "$<$<CONFIG:debug>:0>$<$<CONFIG:release>:3>$<$<CONFIG:relwithdebinfo>:3>$<$<CONFIG:minsizerel>:3>"
 				VARYINGDEF ${ARGS_VARYING_DEF}
-				INCLUDES ${BGFX_SHADER_INCLUDE_PATH}
+				INCLUDES ${BGFX_SHADER_INCLUDE_PATH} ${ARGS_INCLUDE_DIRS}
 				BIN2C BIN2C ${SHADER_FILE_NAME_WE}_${PROFILE_EXT}
 			)
 			list(APPEND OUTPUTS ${OUTPUT})
 			list(APPEND COMMANDS COMMAND bgfx::shaderc ${CLI})
 		endforeach()
+		if(DEFINED ARGS_OUT_FILES_VAR)
+			set(${ARGS_OUT_FILES_VAR} ${OUTPUTS} PARENT_SCOPE)
+		endif()
 
 		add_custom_command(
 			OUTPUT ${OUTPUTS}

--- a/cmake/bimg/texturec.cmake
+++ b/cmake/bimg/texturec.cmake
@@ -22,13 +22,10 @@ set_target_properties(
 						OUTPUT_NAME ${BGFX_TOOLS_PREFIX}texturec #
 )
 
-if(BGFX_BUILD_TOOLS_TEXTURE AND BGFX_CUSTOM_TARGETS)
-	add_dependencies(tools texturec)
-endif()
-
 if(BGFX_BUILD_TOOLS_TEXTURE)
-	if(TARGET texturec AND NOT TARGET bgfx::texturec)
-		add_executable(bgfx::texturec ALIAS texturec)
+	add_executable(bgfx::texturec ALIAS texturec)
+	if(BGFX_CUSTOM_TARGETS)
+		add_dependencies(tools texturec)
 	endif()
 endif()
 

--- a/cmake/bimg/texturec.cmake
+++ b/cmake/bimg/texturec.cmake
@@ -26,6 +26,12 @@ if(BGFX_BUILD_TOOLS_TEXTURE AND BGFX_CUSTOM_TARGETS)
 	add_dependencies(tools texturec)
 endif()
 
+if(BGFX_BUILD_TOOLS_TEXTURE)
+	if(TARGET texturec AND NOT TARGET bgfx::texturec)
+		add_executable(bgfx::texturec ALIAS texturec)
+	endif()
+endif()
+
 if(ANDROID)
 	target_link_libraries(texturec PRIVATE log)
 elseif(IOS)

--- a/cmake/bx/bin2c.cmake
+++ b/cmake/bx/bin2c.cmake
@@ -22,13 +22,10 @@ set_target_properties(
 					 OUTPUT_NAME ${BGFX_TOOLS_PREFIX}bin2c #
 )
 
-if(BGFX_BUILD_TOOLS_BIN2C AND BGFX_CUSTOM_TARGETS)
-	add_dependencies(tools bin2c)
-endif()
-
 if(BGFX_BUILD_TOOLS_BIN2C)
-	if(TARGET bin2c AND NOT TARGET bgfx::bin2c)
-		add_executable(bgfx::bin2c ALIAS bin2c)
+	add_executable(bgfx::bin2c ALIAS bin2c)
+	if(BGFX_CUSTOM_TARGETS)
+		add_dependencies(tools bin2c)
 	endif()
 endif()
 

--- a/cmake/bx/bin2c.cmake
+++ b/cmake/bx/bin2c.cmake
@@ -26,6 +26,12 @@ if(BGFX_BUILD_TOOLS_BIN2C AND BGFX_CUSTOM_TARGETS)
 	add_dependencies(tools bin2c)
 endif()
 
+if(BGFX_BUILD_TOOLS_BIN2C)
+	if(TARGET bin2c AND NOT TARGET bgfx::bin2c)
+		add_executable(bgfx::bin2c ALIAS bin2c)
+	endif()
+endif()
+
 if(ANDROID)
 	target_link_libraries(bin2c PRIVATE log)
 elseif(IOS)


### PR DESCRIPTION
The custom command didn't recognize bgfx::shaderc and the generator expression seems bettter. I also added an include option since it might be important to be able to define those.