### PR TITLE
ew option to allow "example-common" project to not be included in build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,10 @@ cmake_dependent_option(BGFX_BUILD_TOOLS_SHADER "Build bgfx shader tools." ON BGF
 cmake_dependent_option(BGFX_BUILD_TOOLS_GEOMETRY "Build bgfx geometry tools." ON BGFX_BUILD_TOOLS OFF)
 cmake_dependent_option(BGFX_BUILD_TOOLS_TEXTURE "Build bgfx texture tools." ON BGFX_BUILD_TOOLS OFF)
 set(BGFX_TOOLS_PREFIX "" CACHE STRING "Prefix name to add to name of tools (to avoid clashes)")
-option(BGFX_BUILD_EXAMPLE_COMMON "Build bgfx example-common project." ON)
 option(BGFX_BUILD_EXAMPLES "Build bgfx examples." ON)
+cmake_dependent_option(
+	BGFX_BUILD_EXAMPLE_COMMON "Build bgfx example-common project." OFF "NOT BGFX_BUILD_EXAMPLES;NOT BGFX_BUILD_TOOLS" ON
+)
 option(BGFX_BUILD_TESTS "Build bgfx tests." OFF)
 option(BGFX_INSTALL "Create installation target." ON)
 cmake_dependent_option(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,8 @@ cmake_dependent_option(BGFX_BUILD_TOOLS_TEXTURE "Build bgfx texture tools." ON B
 set(BGFX_TOOLS_PREFIX "" CACHE STRING "Prefix name to add to name of tools (to avoid clashes)")
 option(BGFX_BUILD_EXAMPLES "Build bgfx examples." ON)
 cmake_dependent_option(
-	BGFX_BUILD_EXAMPLE_COMMON "Build bgfx example-common project." OFF "NOT BGFX_BUILD_EXAMPLES;NOT BGFX_BUILD_TOOLS" ON
+	BGFX_BUILD_EXAMPLE_COMMON "Build bgfx example-common project." OFF "NOT BGFX_BUILD_EXAMPLES;NOT BGFX_BUILD_TOOLS"
+	ON
 )
 option(BGFX_BUILD_TESTS "Build bgfx tests." OFF)
 option(BGFX_INSTALL "Create installation target." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ cmake_dependent_option(BGFX_BUILD_TOOLS_SHADER "Build bgfx shader tools." ON BGF
 cmake_dependent_option(BGFX_BUILD_TOOLS_GEOMETRY "Build bgfx geometry tools." ON BGFX_BUILD_TOOLS OFF)
 cmake_dependent_option(BGFX_BUILD_TOOLS_TEXTURE "Build bgfx texture tools." ON BGFX_BUILD_TOOLS OFF)
 set(BGFX_TOOLS_PREFIX "" CACHE STRING "Prefix name to add to name of tools (to avoid clashes)")
+option(BGFX_BUILD_EXAMPLE_COMMON "Build bgfx example-common project." ON)
 option(BGFX_BUILD_EXAMPLES "Build bgfx examples." ON)
 option(BGFX_BUILD_TESTS "Build bgfx tests." OFF)
 option(BGFX_INSTALL "Create installation target." ON)

--- a/cmake/bgfx/examples.cmake
+++ b/cmake/bgfx/examples.cmake
@@ -263,17 +263,19 @@ if(BGFX_CUSTOM_TARGETS)
 endif()
 
 # Add common library for examples
-add_example(
-	common
-	COMMON
-	DIRECTORIES
-	${BGFX_DIR}/examples/common/debugdraw
-	${BGFX_DIR}/examples/common/entry
-	${BGFX_DIR}/examples/common/font
-	${BGFX_DIR}/examples/common/imgui
-	${BGFX_DIR}/examples/common/nanovg
-	${BGFX_DIR}/examples/common/ps
-)
+if(BGFX_BUILD_EXAMPLE_COMMON)
+	add_example(
+		common
+		COMMON
+		DIRECTORIES
+		${BGFX_DIR}/examples/common/debugdraw
+		${BGFX_DIR}/examples/common/entry
+		${BGFX_DIR}/examples/common/font
+		${BGFX_DIR}/examples/common/imgui
+		${BGFX_DIR}/examples/common/nanovg
+		${BGFX_DIR}/examples/common/ps
+	)
+endif()
 
 # Only add examples if set, otherwise we still need exmaples common for tools
 if(BGFX_BUILD_EXAMPLES)


### PR DESCRIPTION
I added a new option `BGFX_BUILD_EXAMPLE_COMMON` to allow users to opt out of the example-common project from being added to their solutions. It defaults to `On` to match the default for `BGFX_BUILD_EXAMPLES` which relies on it.

I created a new option to allow users to continue to use `example-common` in their project without adding the rest of the examples and to preserve the existing behaviour.

Fixes #224 