### PR TITLE
tools: Add an option to insert search paths for tools

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -14,6 +14,7 @@ macro(_bgfx_crosscompile_use_host_tool TOOL_NAME)
 		find_program(
 			${TOOL_NAME}_EXECUTABLE
 			NAMES bgfx-${TOOL_NAME} ${TOOL_NAME}
+			PATHS @BGFX_ADDITIONAL_TOOL_PATHS@ /usr/bin
 		)
 		add_executable(bgfx::${TOOL_NAME} IMPORTED)
 		set_target_properties(bgfx::${TOOL_NAME} PROPERTIES IMPORTED_LOCATION "${${TOOL_NAME}_EXECUTABLE}")


### PR DESCRIPTION
Unfortunately this is necessary to be able to cross compile using vcpkg for the moment.
ref: https://github.com/microsoft/vcpkg/pull/38816