### PR TITLE
Make `bgfx_compile_shaders` more generic

### DIFF
--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -598,9 +598,10 @@ if(TARGET bgfx::shaderc)
 			# Build output targets and their commands
 			set(OUTPUTS "")
 			set(COMMANDS "")
+			set(MKDIR_COMMANDS "")
 			foreach(PROFILE ${PROFILES})
 				_bgfx_get_profile_ext(${PROFILE} PROFILE_EXT)
-				set(OUTPUT ${ARGS_OUTPUT_DIR}/${SHADER_FILE_BASENAME}.${PROFILE_EXT}.bin$<ARGS_AS_HEADERS:.h>)
+				set(OUTPUT ${ARGS_OUTPUT_DIR}/${PROFILE_EXT}/${SHADER_FILE_BASENAME}.bin$<$<BOOL:ARGS_AS_HEADERS>:.h>)
 				set(PLATFORM_I ${PLATFORM})
 				if(PROFILE STREQUAL "spirv")
 					set(PLATFORM_I LINUX)
@@ -622,12 +623,21 @@ if(TARGET bgfx::shaderc)
 				)
 				list(APPEND OUTPUTS ${OUTPUT})
 				list(APPEND ALL_OUTPUTS ${OUTPUT})
+				list(
+					APPEND
+					MKDIR_COMMANDS
+					COMMAND
+					${CMAKE_COMMAND}
+					-E
+					make_directory
+					${ARGS_OUTPUT_DIR}/${PROFILE_EXT}
+				)
 				list(APPEND COMMANDS COMMAND bgfx::shaderc ${CLI})
 			endforeach()
 
 			add_custom_command(
 				OUTPUT ${OUTPUTS}
-				COMMAND ${CMAKE_COMMAND} -E make_directory ${ARGS_OUTPUT_DIR} ${COMMANDS}
+				COMMAND ${MKDIR_COMMANDS} ${COMMANDS}
 				MAIN_DEPENDENCY ${SHADER_FILE_ABSOLUTE}
 				DEPENDS ${ARGS_VARYING_DEF}
 			)

--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -567,7 +567,7 @@ if(TARGET bgfx::shaderc)
 		set(multiValueArgs SHADERS INCLUDE_DIRS)
 		cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
 
-		set(PROFILES 120 300_es spirv) # pssl
+		set(PROFILES 120 300_es spirv)
 		if(UNIX AND NOT APPLE)
 			set(PLATFORM LINUX)
 		elseif(EMSCRIPTEN)
@@ -585,6 +585,8 @@ if(TARGET bgfx::shaderc)
 			list(APPEND PROFILES s_4_0)
 			list(APPEND PROFILES s_5_0)
 		else()
+			# pssl for Agc and Gnm renderers
+			# nvn for Nvn renderer
 			message(error "shaderc: Unsupported platform")
 		endif()
 


### PR DESCRIPTION
Allow compiling as header or as binaries