### PR TITLE
Improve shader profile extension to be more compatible with bgfx

### DIFF
--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -542,7 +542,6 @@ if(TARGET bgfx::shaderc)
 	function(_bgfx_get_profile_ext PROFILE PROFILE_EXT)
 		string(REPLACE 300_es essl PROFILE ${PROFILE})
 		string(REPLACE 120 glsl PROFILE ${PROFILE})
-		string(REPLACE s_3_0 dx9 PROFILE ${PROFILE})
 		string(REPLACE s_4_0 dx10 PROFILE ${PROFILE})
 		string(REPLACE s_5_0 dx11 PROFILE ${PROFILE})
 

--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -215,7 +215,7 @@ if(TARGET bgfx::texturec)
 		add_custom_command(
 			OUTPUT ${ARG_OUTPUT} #
 			COMMAND bgfx::texturec ${CLI} #
-			MAIN_DEPENDENCY ${ARG_INPUT} #
+			MAIN_DEPENDENCY ${ARG_FILE} #
 		)
 	endfunction()
 endif()
@@ -279,12 +279,12 @@ if(TARGET bgfx::geometryc)
 
 		# --packnormal
 		if(ARG_PACKNORMAL)
-			list(APPEND CLI "--packnormal ${ARG_PACKNORMAL}")
+			list(APPEND CLI "--packnormal" "${ARG_PACKNORMAL}")
 		endif()
 
 		# --packuv
 		if(ARG_PACKUV)
-			list(APPEND CLI "--packuv" ${ARG_PACKUV})
+			list(APPEND CLI "--packuv" "${ARG_PACKUV}")
 		endif()
 
 		# --tangent
@@ -352,7 +352,7 @@ if(TARGET bgfx::geometryc)
 		add_custom_command(
 			OUTPUT ${ARG_OUTPUT} #
 			COMMAND bgfx::geometryc ${CLI} #
-			MAIN_DEPENDENCY ${ARG_INPUT} #
+			MAIN_DEPENDENCY ${ARG_FILE} #
 		)
 	endfunction()
 endif()
@@ -542,8 +542,6 @@ if(TARGET bgfx::shaderc)
 	function(_bgfx_get_profile_ext PROFILE PROFILE_EXT)
 		string(REPLACE 300_es essl PROFILE ${PROFILE})
 		string(REPLACE 120 glsl PROFILE ${PROFILE})
-		string(REPLACE spirv spv PROFILE ${PROFILE})
-		string(REPLACE metal mtl PROFILE ${PROFILE})
 		string(REPLACE s_3_0 dx9 PROFILE ${PROFILE})
 		string(REPLACE s_4_0 dx10 PROFILE ${PROFILE})
 		string(REPLACE s_5_0 dx11 PROFILE ${PROFILE})

--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -539,12 +539,23 @@ if(TARGET bgfx::shaderc)
 		set(${ARG_OUT} ${CLI} PARENT_SCOPE)
 	endfunction()
 
-	function(_bgfx_get_profile_ext PROFILE PROFILE_EXT)
+	# extensions consistent with those listed under bgfx/runtime/shaders
+	function(_bgfx_get_profile_path_ext PROFILE PROFILE_PATH_EXT)
 		string(REPLACE 300_es essl PROFILE ${PROFILE})
 		string(REPLACE 120 glsl PROFILE ${PROFILE})
 		string(REPLACE s_4_0 dx10 PROFILE ${PROFILE})
 		string(REPLACE s_5_0 dx11 PROFILE ${PROFILE})
+		set(${PROFILE_PATH_EXT} ${PROFILE} PARENT_SCOPE)
+	endfunction()
 
+	# extensions consistent with embedded_shader.h
+	function(_bgfx_get_profile_ext PROFILE PROFILE_EXT)
+		string(REPLACE 300_es essl PROFILE ${PROFILE})
+		string(REPLACE 120 glsl PROFILE ${PROFILE})
+		string(REPLACE spirv spv PROFILE ${PROFILE})
+		string(REPLACE metal mtl PROFILE ${PROFILE})
+		string(REPLACE s_4_0 dx10 PROFILE ${PROFILE})
+		string(REPLACE s_5_0 dx11 PROFILE ${PROFILE})
 		set(${PROFILE_EXT} ${PROFILE} PARENT_SCOPE)
 	endfunction()
 
@@ -599,11 +610,12 @@ if(TARGET bgfx::shaderc)
 			set(COMMANDS "")
 			set(MKDIR_COMMANDS "")
 			foreach(PROFILE ${PROFILES})
+				_bgfx_get_profile_path_ext(${PROFILE} PROFILE_PATH_EXT)
 				_bgfx_get_profile_ext(${PROFILE} PROFILE_EXT)
 				if(ARGS_AS_HEADERS)
 					set(HEADER_PREFIX .h)
 				endif()
-				set(OUTPUT ${ARGS_OUTPUT_DIR}/${PROFILE_EXT}/${SHADER_FILE_BASENAME}.bin${HEADER_PREFIX})
+				set(OUTPUT ${ARGS_OUTPUT_DIR}/${PROFILE_PATH_EXT}/${SHADER_FILE_BASENAME}.bin${HEADER_PREFIX})
 				set(PLATFORM_I ${PLATFORM})
 				if(PROFILE STREQUAL "spirv")
 					set(PLATFORM_I LINUX)
@@ -632,7 +644,7 @@ if(TARGET bgfx::shaderc)
 					${CMAKE_COMMAND}
 					-E
 					make_directory
-					${ARGS_OUTPUT_DIR}/${PROFILE_EXT}
+					${ARGS_OUTPUT_DIR}/${PROFILE_PATH_EXT}
 				)
 				list(APPEND COMMANDS COMMAND bgfx::shaderc ${CLI})
 			endforeach()


### PR DESCRIPTION
Currently, the profiles `spirv` and `metal` are abbreviated to `spv` and `mtl`, which means the compiled shaders are in the directories `spv` and `mtl`. This is different from the convention used in bgfx (see `bgfx/examples/runtime`), which leaves them as `spirv` and `metal`. Conforming to the bgfx has an added benefit: it is now possible to directly use the `loadShader` and `loadProgram` functions defined in bgfx_utils (in `bgfx/examples/common/`) just like the example programs. This was not possible before since the extensions `spirv` and `metal` were hard-coded into bgfx_utils.

Example:

In the `CMakeLists.txt` at the root of the project:
```cmake
bgfx_compile_shaders(
	TYPE VERTEX
	SHADERS ${CMAKE_SOURCE_DIR}/shaders/vs.sc
	VARYING_DEF ${CMAKE_SOURCE_DIR}/shaders/varying.def.sc
    INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/bgfx.cmake/bgfx/examples/" "${CMAKE_SOURCE_DIR}/bgfx.cmake/bgfx/src/"
	OUTPUT_DIR ${CMAKE_BINARY_DIR}/shaders
)

bgfx_compile_shaders(
	TYPE FRAGMENT
	SHADERS ${CMAKE_SOURCE_DIR}/shaders/fs.sc
	VARYING_DEF ${CMAKE_SOURCE_DIR}/shaders/varying.def.sc
    INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/bgfx.cmake/bgfx/examples/" "${CMAKE_SOURCE_DIR}/bgfx.cmake/bgfx/src/"
	OUTPUT_DIR ${CMAKE_BINARY_DIR}/shaders
)

add_executable(main src/main.cpp 
    shaders/vs.sc 
    shaders/fs.sc
)
```

In `main.cpp`:

```cpp
// ...
#include "bgfx_utils.h"
// ...
bgfx::ProgramHandle m_program = loadProgram("vs.sc", "fs.sc");
```