### PR TITLE
Fixing Wayland cmake definitions and linkage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt install -y libgl1-mesa-dev
+          sudo apt install -y libgl1-mesa-dev libwayland-dev libwayland-egl-backend-dev
       - uses: lukka/get-cmake@latest
         with:
           cmakeVersion: ${{ env.CMAKE_VERSION }}
@@ -63,7 +63,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt install -y libgl1-mesa-dev
+          sudo apt install -y libgl1-mesa-dev libwayland-dev libwayland-egl-backend-dev
         if: matrix.os == 'ubuntu-latest'
 
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
@@ -100,7 +100,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt install -y libgl1-mesa-dev
+          sudo apt install -y libgl1-mesa-dev libwayland-dev libwayland-egl-backend-dev
         if: matrix.os == 'ubuntu-latest'
 
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt install -y libgl1-mesa-dev
+          sudo apt install -y libgl1-mesa-dev libwayland-dev libwayland-egl-backend-dev
         if: matrix.os == 'ubuntu-latest'
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ option(BGFX_INSTALL "Create installation target." ON)
 cmake_dependent_option(
 	BGFX_INSTALL_EXAMPLES "Install examples and their runtimes." OFF "BGFX_INSTALL;BGFX_BUILD_EXAMPLES" OFF
 )
-cmake_dependent_option(BGFX_WITH_WAYLAND "Use Wayland backend." ON "CMAKE_SYSTEM_NAME STREQUAL 'Linux'" OFF)
+cmake_dependent_option(BGFX_WITH_WAYLAND "Use Wayland backend." ON "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
 option(BGFX_CUSTOM_TARGETS "Include convenience custom targets." ON)
 option(BGFX_CONFIG_MULTITHREADED "Build bgfx with multithreaded configuration" ON)
 option(BGFX_CONFIG_RENDERER_WEBGPU "Enable the webgpu renderer" OFF)

--- a/cmake/bgfx/bgfx.cmake
+++ b/cmake/bgfx/bgfx.cmake
@@ -87,6 +87,7 @@ endif()
 
 if(BGFX_WITH_WAYLAND)
 	target_compile_definitions(bgfx PRIVATE "WL_EGL_PLATFORM=1")
+	target_link_libraries(bgfx PRIVATE wayland-egl)
 endif()
 
 set(BGFX_CONFIG_OPTIONS "")

--- a/cmake/bgfx/examples.cmake
+++ b/cmake/bgfx/examples.cmake
@@ -136,14 +136,19 @@ function(add_example ARG_NAME)
 		target_link_libraries(
 			example-${ARG_NAME} PUBLIC bgfx bx bimg bimg_decode ${DEAR_IMGUI_LIBRARIES} ${MESHOPTIMIZER_LIBRARIES}
 		)
+
+		if(BGFX_WITH_WAYLAND)
+			target_compile_definitions(example-${ARG_NAME} PUBLIC ENTRY_CONFIG_USE_WAYLAND=1)
+		endif()
+
 		if(BGFX_WITH_GLFW)
 			find_package(glfw3 REQUIRED)
 			target_link_libraries(example-${ARG_NAME} PUBLIC glfw)
-			target_compile_definitions(example-${ARG_NAME} PUBLIC ENTRY_CONFIG_USE_GLFW)
+			target_compile_definitions(example-${ARG_NAME} PUBLIC ENTRY_CONFIG_USE_GLFW=1)
 		elseif(BGFX_WITH_SDL)
 			find_package(SDL2 REQUIRED)
 			target_link_libraries(example-${ARG_NAME} PUBLIC ${SDL2_LIBRARIES})
-			target_compile_definitions(example-${ARG_NAME} PUBLIC ENTRY_CONFIG_USE_SDL)
+			target_compile_definitions(example-${ARG_NAME} PUBLIC ENTRY_CONFIG_USE_SDL=1)
 		elseif(UNIX AND NOT APPLE AND NOT ANDROID)
 			target_link_libraries(example-${ARG_NAME} PUBLIC X11)
 		endif()


### PR DESCRIPTION
In newer versions of cmake this line triggers a CMP0127 warning. Removing the quotes because they're not needed in older versions of cmake and doesn't trigger the warning in newer version of cmake.