### PR TITLE
Fixed bgfx_compile_shaders incorrectly generating output path, and generat quality of life update for all tool util functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The generated headers will have names in the format of `${RENDERING_API}/${SHADE
 
 Adding these `SHADERS` as source files to a target will run `shaderc` at build time and they will rebuild if either the contents of the `SHADERS` or the `VARYING_DEF` change.
 
+Logs generated from compilation will be located in the `bgfx_tool_logs` directory within the build folder.
+
 #### Examples: Generating shaders as headers
 ```cmake
 bgfx_compile_shaders(

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This defines a bin2c command to generate a specified `OUTPUT_FILE` header with a
 
 Adding these `INPUT_FILE` as source files to a target will run `bin2c` at build time and they will rebuild if either the contents of the `INPUT_FILE` change.
 
+Logs generated from compilation will be located in the `bgfx_tool_logs` directory within the build folder.
+
 #### Examples: Generating an image as a header
 ```cmake
 bgfx_compile_binary_to_header(

--- a/README.md
+++ b/README.md
@@ -88,6 +88,31 @@ bgfx_compile_texture(
 )
 ```
 
+Logs generated from compilation will be located in the `bgfx_tool_logs` directory within the build folder.
+
+### `bgfx_compile_geometry`
+Add a build rule for a geometry to the generated build system be compiled using geometryc.
+```cmake
+bgfx_compile_geometry(
+     FILE filename
+     OUTPUT filename
+     [SCALE scale]
+     [CCW]
+     [FLIPV]
+     [OBB num steps]
+     [PACKNORMAL 0|1]
+     [PACKUV 0|1]
+     [TANGENT]
+     [BARYCENTRIC]
+     [COMPRESS]
+     [LH_UP_Y|LH_UP_Z|RH_UP_Y|RH_UP_Z]
+)
+
+```
+
+Logs generated from compilation will be located in the `bgfx_tool_logs` directory within the build folder.
+
+
 ### `bgfx_compile_shaders`
 Add a build rule for a `*.sc` shader to the generated build system using shaderc.
 ```cmake

--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -56,12 +56,14 @@ if(TARGET bgfx::bin2c)
 			ARRAY_NAME ${ARG_ARRAY_NAME}
 		)
 
+        get_filename_component(OUTPUT_DIR "${ARG_OUTPUT_FILE}" DIRECTORY)
+        file(MAKE_DIRECTORY ${OUTPUT_DIR}) # create output path if it does not exist
 		file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/bgfx_tool_logs) # create log path if it does not exist
-        file(MAKE_DIRECTORY ${ARGS_OUTPUT_DIR}/${PROFILE_PATH_EXT}) # create output path if it does not exist
         file(RELATIVE_PATH INPUT_FILE_RELATIVE ${CMAKE_BINARY_DIR} ${ARG_INPUT_FILE})
         file(RELATIVE_PATH OUTPUT_FILE_RELATIVE ${CMAKE_BINARY_DIR} ${ARG_OUTPUT_FILE})
 
-        string(REPLACE "/" "-"  FILE_NAME_APPROPRIATE_OUTPUT_PATH ${OUTPUT_FILE_RELATIVE})
+        string(REPLACE " " "_"  FILE_NAME_APPROPRIATE_OUTPUT_PATH ${OUTPUT_FILE_RELATIVE})
+        string(REPLACE "/" "-"  FILE_NAME_APPROPRIATE_OUTPUT_PATH ${FILE_NAME_APPROPRIATE_OUTPUT_PATH})
         string(REPLACE "\\" "-"  FILE_NAME_APPROPRIATE_OUTPUT_PATH ${FILE_NAME_APPROPRIATE_OUTPUT_PATH}) # probably need this for windows
 
 		add_custom_command(
@@ -226,11 +228,26 @@ if(TARGET bgfx::texturec)
 			${ARGN} #
 		)
 		_bgfx_texturec_parse(CLI ${ARGV})
+
+        get_filename_component(OUTPUT_DIR "${ARG_OUTPUT}" DIRECTORY)
+        file(MAKE_DIRECTORY ${OUTPUT_DIR}) # create output path if it does not exist
+		file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/bgfx_tool_logs) # create log path if it does not exist
+        file(RELATIVE_PATH INPUT_FILE_RELATIVE ${CMAKE_BINARY_DIR} ${ARG_FILE})
+        file(RELATIVE_PATH OUTPUT_FILE_RELATIVE ${CMAKE_BINARY_DIR} ${ARG_OUTPUT})
+
+        string(REPLACE " " "_"  FILE_NAME_APPROPRIATE_OUTPUT_PATH ${OUTPUT_FILE_RELATIVE})
+        string(REPLACE "/" "-"  FILE_NAME_APPROPRIATE_OUTPUT_PATH ${FILE_NAME_APPROPRIATE_OUTPUT_PATH})
+        string(REPLACE "\\" "-"  FILE_NAME_APPROPRIATE_OUTPUT_PATH ${FILE_NAME_APPROPRIATE_OUTPUT_PATH}) # probably need this for windows
+
 		add_custom_command(
 			OUTPUT ${ARG_OUTPUT} #
-			COMMAND bgfx::texturec ${CLI} #
+			COMMAND bgfx::texturec ${CLI} > bgfx_tool_logs/texture_compile_output_${FILE_NAME_APPROPRIATE_OUTPUT_PATH}.log#
 			MAIN_DEPENDENCY ${ARG_FILE} #
 		)
+
+        add_custom_target(${FILE_NAME_APPROPRIATE_OUTPUT_PATH} ALL
+             DEPENDS ${ARG_OUTPUT}
+        )
 	endfunction()
 endif()
 

--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -69,12 +69,13 @@ if(TARGET bgfx::bin2c)
 		add_custom_command(
 			OUTPUT ${ARG_OUTPUT_FILE} #
 			COMMAND bgfx::bin2c ${CLI} > bgfx_tool_logs/binary_to_header_compile_output_${FILE_NAME_APPROPRIATE_OUTPUT_PATH}.log #
-            COMMENT "Compiling ${INPUT_FILE_RELATIVE} as header"
+            COMMENT "Compiling ${INPUT_FILE_RELATIVE} as header" #
 			MAIN_DEPENDENCY ${ARG_INPUT_FILE} #
 		)
 
-        add_custom_target(${FILE_NAME_APPROPRIATE_OUTPUT_PATH} ALL
-             DEPENDS ${ARG_OUTPUT_FILE}
+        add_custom_target(
+            ${FILE_NAME_APPROPRIATE_OUTPUT_PATH} ALL #
+             DEPENDS ${ARG_OUTPUT_FILE} #
         )
 	endfunction()
 endif()
@@ -241,12 +242,14 @@ if(TARGET bgfx::texturec)
 
 		add_custom_command(
 			OUTPUT ${ARG_OUTPUT} #
-			COMMAND bgfx::texturec ${CLI} > bgfx_tool_logs/texture_compile_output_${FILE_NAME_APPROPRIATE_OUTPUT_PATH}.log#
+			COMMAND bgfx::texturec ${CLI} > bgfx_tool_logs/texture_compile_output_${FILE_NAME_APPROPRIATE_OUTPUT_PATH}.log #
+            COMMENT "Compiling ${INPUT_FILE_RELATIVE}" #
 			MAIN_DEPENDENCY ${ARG_FILE} #
 		)
 
-        add_custom_target(${FILE_NAME_APPROPRIATE_OUTPUT_PATH} ALL
-             DEPENDS ${ARG_OUTPUT}
+        add_custom_target(
+             ${FILE_NAME_APPROPRIATE_OUTPUT_PATH} ALL #
+             DEPENDS ${ARG_OUTPUT} #
         )
 	endfunction()
 endif()
@@ -380,11 +383,28 @@ if(TARGET bgfx::geometryc)
 			${ARGN} #
 		)
 		_bgfx_geometryc_parse(CLI ${ARGV})
+
+        get_filename_component(OUTPUT_DIR "${ARG_OUTPUT}" DIRECTORY)
+        file(MAKE_DIRECTORY ${OUTPUT_DIR}) # create output path if it does not exist
+		file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/bgfx_tool_logs) # create log path if it does not exist
+        file(RELATIVE_PATH INPUT_FILE_RELATIVE ${CMAKE_BINARY_DIR} ${ARG_FILE})
+        file(RELATIVE_PATH OUTPUT_FILE_RELATIVE ${CMAKE_BINARY_DIR} ${ARG_OUTPUT})
+
+        string(REPLACE " " "_"  FILE_NAME_APPROPRIATE_OUTPUT_PATH ${OUTPUT_FILE_RELATIVE})
+        string(REPLACE "/" "-"  FILE_NAME_APPROPRIATE_OUTPUT_PATH ${FILE_NAME_APPROPRIATE_OUTPUT_PATH})
+        string(REPLACE "\\" "-"  FILE_NAME_APPROPRIATE_OUTPUT_PATH ${FILE_NAME_APPROPRIATE_OUTPUT_PATH}) # probably need this for windows
+
 		add_custom_command(
 			OUTPUT ${ARG_OUTPUT} #
-			COMMAND bgfx::geometryc ${CLI} #
+			COMMAND bgfx::geometryc ${CLI} > bgfx_tool_logs/geometry_compile_output_${FILE_NAME_APPROPRIATE_OUTPUT_PATH}.log #
+            COMMENT "Compiling ${INPUT_FILE_RELATIVE}" #
 			MAIN_DEPENDENCY ${ARG_FILE} #
 		)
+
+        add_custom_target(
+             ${FILE_NAME_APPROPRIATE_OUTPUT_PATH} ALL #
+             DEPENDS ${ARG_OUTPUT} #
+        )
 	endfunction()
 endif()
 
@@ -689,15 +709,16 @@ if(TARGET bgfx::shaderc)
             endif()
 
 			add_custom_command(
-				OUTPUT ${OUTPUTS}
-				COMMAND ${COMMANDS}
-				MAIN_DEPENDENCY ${SHADER_FILE_ABSOLUTE}
-                COMMENT "Compiling ${TARGET_NAME}"
-				DEPENDS ${ARGS_VARYING_DEF}
+				OUTPUT ${OUTPUTS} #
+				COMMAND ${COMMANDS} #
+				MAIN_DEPENDENCY ${SHADER_FILE_ABSOLUTE} #
+                COMMENT "Compiling ${TARGET_NAME}" #
+				DEPENDS ${ARGS_VARYING_DEF} #
 			)
 
-            add_custom_target(${FILE_NAME_APPROPRIATE_OUTPUT_PATH} ALL
-                DEPENDS ${OUTPUTS}
+            add_custom_target(
+                ${FILE_NAME_APPROPRIATE_OUTPUT_PATH} ALL #
+                DEPENDS ${OUTPUTS} #
             )
 		endforeach()
 

--- a/cmake/bgfxToolUtils.cmake
+++ b/cmake/bgfxToolUtils.cmake
@@ -650,15 +650,25 @@ if(TARGET bgfx::shaderc)
 
             file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/bgfx_tool_logs)
 
+            # This is to prevent error if compiling as binary and header in same directory
+            set(TARGET_NAME "${SHADER_FILE_RELATIVE}")
+            if(ARGS_AS_HEADERS)  
+                set(TARGET_NAME "${SHADER_FILE_RELATIVE} As header")
+            endif()
+
 			add_custom_command(
 				OUTPUT ${OUTPUTS}
 				COMMAND ${COMMANDS}
 				MAIN_DEPENDENCY ${SHADER_FILE_ABSOLUTE}
-                COMMENT "Compiling ${SHADER_FILE_RELATIVE}"
+                COMMENT "Compiling ${TARGET_NAME}"
 				DEPENDS ${ARGS_VARYING_DEF}
 			)
 
-            add_custom_target(${SHADER_FILE_RELATIVE} ALL
+            string(REPLACE " " "_"  TARGET_APPROPRIATE_NAME ${TARGET_NAME}) # Target name can not contain space
+            string(REPLACE "/" "-"  TARGET_APPROPRIATE_NAME ${TARGET_APPROPRIATE_NAME})
+            string(REPLACE "\\" "-"  TARGET_APPROPRIATE_NAME ${TARGET_APPROPRIATE_NAME}) # probably need this for windows
+
+            add_custom_target(${TARGET_APPROPRIATE_NAME} ALL
                 DEPENDS ${OUTPUTS}
             )
 		endforeach()


### PR DESCRIPTION
changes in 'bgfx_compile_geometry', 'bgfx_compile_texture', 'bgfx_compile_binary_to_header' and 'bgfx_compile_shaders':
- If path doesnt exist to output path, it will be generated on build system generation. (fix for bgfx_compile_shaders, adition to rest of functions)

- All these functions create log file in 'bgfx_tool_logs' directory in root of build directory.
  ex: 

      binary_to_header_compile_output_..-assets-bin-compiled-test.h.log
      -------------------------------   ---------------------------------
                        tool used            relative path to asset output
                        
      shader_compile_output_..-assets-shaders-essl-vs.sc.bin.h.log
      ---------------------    ---------------------------------
                tool used         relative path to asset output

                
also i added mention in readme for 'bgfx_compile_geometry' which was missing for some reason

i have only tested this on linux. i have no access windows or others atm

i also had to call add_custom_target for each functions else it didnt run

```
add_custom_command(
	OUTPUT ${OUTPUTS} #
	COMMAND ${COMMANDS} #
	MAIN_DEPENDENCY ${SHADER_FILE_ABSOLUTE} #
        COMMENT "Compiling ${TARGET_NAME}" #
	DEPENDS ${ARGS_VARYING_DEF} #
)

add_custom_target(
        ${FILE_NAME_APPROPRIATE_OUTPUT_PATH} ALL #
        DEPENDS ${OUTPUTS} #
)
```
