### PR TITLE
actions: bump actions. fixes upload-artifact@v3 failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       CMAKE_VERSION: 3.10.2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install Linux dependencies
@@ -57,7 +57,7 @@ jobs:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install Linux dependencies
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install Linux dependencies

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
     name: cmake-format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -21,7 +21,7 @@ jobs:
         if: startsWith(github.event_name, 'pull_request')
       - name: Format CMake files
         id: cmake-format
-        uses: PuneetMatharu/cmake-format-lint-action@main
+        uses: PuneetMatharu/cmake-format-lint-action@v1.0.6
         with:
           args: --config-files .cmake-format.py --check
   # Run only if a PR and cmake-format has failed
@@ -31,7 +31,7 @@ jobs:
     needs: cmake-format-check
     if: always() && startsWith(github.event_name, 'pull_request') && needs.cmake-format-check.result == 'failure'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -40,7 +40,7 @@ jobs:
         if: startsWith(github.event_name, 'pull_request')
       - name: Format CMake files
         id: cmake-format
-        uses: PuneetMatharu/cmake-format-lint-action@v1.0.0
+        uses: PuneetMatharu/cmake-format-lint-action@v1.0.6
         with:
           args: --config-files .cmake-format.py --in-place
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       sha: ${{ steps.version.outputs.sha }}
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -51,7 +51,7 @@ jobs:
       CMAKE_INSTALL_DIR: ${{ github.workspace }}/install/
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install Linux dependencies
@@ -80,7 +80,7 @@ jobs:
       - name: Build
         run: |
           cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target install --config Release
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}
           path: ${{ github.workspace }}/install/
@@ -93,7 +93,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -102,69 +102,69 @@ jobs:
           find src/bgfx.cmake -name ".git*" -exec rm -rf {} +
           find src/bgfx.cmake -name ".editorconfig" -delete
           rm src/bgfx.cmake/.cmake-format.py
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: windows-latest
           path: ${{ github.workspace }}/install/windows/bgfx.cmake
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ubuntu-latest
           path: ${{ github.workspace }}/install/linux/bgfx.cmake
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: macos-latest
           path: ${{ github.workspace }}/install/macos/bgfx.cmake
       - name: Create Source Zip
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'zip'
           filename: 'bgfx.cmake.${{ needs.version.outputs.tag }}.zip'
           directory: 'src'
           path: 'bgfx.cmake'
       - name: Create Source Tar
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'tar'
           filename: 'bgfx.cmake.${{ needs.version.outputs.tag }}.tar.gz'
           directory: 'src'
           path: 'bgfx.cmake'
       - name: Create Windows Zip
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'zip'
           filename: 'bgfx.cmake.binary.windows.${{ needs.version.outputs.tag }}.zip'
           directory: 'install/windows'
           path: 'bgfx.cmake'
       - name: Create Windows Tar
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'tar'
           filename: 'bgfx.cmake.binary.windows.${{ needs.version.outputs.tag }}.tar.gz'
           directory: 'install/windows'
           path: 'bgfx.cmake'
       - name: Create Linux Zip
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'zip'
           filename: 'bgfx.cmake.binary.linux.${{ needs.version.outputs.tag }}.zip'
           directory: 'install/linux'
           path: 'bgfx.cmake'
       - name: Create Linux Tar
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'tar'
           filename: 'bgfx.cmake.binary.linux.${{ needs.version.outputs.tag }}.tar.gz'
           directory: 'install/linux'
           path: 'bgfx.cmake'
       - name: Create MacOS Zip
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'zip'
           filename: 'bgfx.cmake.binary.macos.${{ needs.version.outputs.tag }}.zip'
           directory: 'install/macos'
           path: 'bgfx.cmake'
       - name: Create MacOS Tar
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'tar'
           filename: 'bgfx.cmake.binary.macos.${{ needs.version.outputs.tag }}.tar.gz'


### PR DESCRIPTION
This PR fixes the pipelines that were no longer running because upload-artifact v3 was disabled.